### PR TITLE
Note issue fixed

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -507,9 +507,9 @@ class Track(BaseModel):
 
 
 class Note(BaseModel):
-    id: str
+    id: int
     text: str
-    user_id: str
+    user_id: int
     user: UserShort
     audience: int
     created_at: datetime


### PR DESCRIPTION
When you either wanted to create a note or get notes, you faced with type error. If we take a look at the response we get when we make requests for note, we can see that now id(which is note id) and user_id of the note are integers now, not strings. This is quick little fix. So, why didn't make this commit to the main repo itself? Well, main repo has problems with login and adding this fix there would make no sense since it can't even login. I added it here, so, when this fork gets merged to main repo, this fix would come along. I didn't take a look at features like video with the note, so it might take some time to add it(Or I might be busy due the christmas and can't even work on it) Anyways, thanks again for fixing login.
Believe it or not but that fix played pretty big role on something ;))) Happy Christmas!